### PR TITLE
Ageinfo workaround

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -33,6 +33,7 @@ def test_create_zip(zip_contents_path):
         "saved-search.js",
         "following.js",
         "follower.js",
+        "ageinfo.js",
     } == {f.filename for f in zf.filelist}
 
 
@@ -77,6 +78,7 @@ def assert_imported_db(db):
         "archive_account",
         "archive_app",
         "archive_following",
+        "archive_ageinfo",
     } == set(db.table_names())
 
     assert [{"accountId": "73747798"}, {"accountId": "386025404"}] == list(

--- a/tests/zip_contents/ageinfo.js
+++ b/tests/zip_contents/ageinfo.js
@@ -1,0 +1,4 @@
+window.YTD.ageinfo.part0 = 
+  {
+    "ageMeta" : { }
+  }

--- a/twitter_to_sqlite/archive.py
+++ b/twitter_to_sqlite/archive.py
@@ -88,6 +88,10 @@ def ad_online_conversions_unattributed(item):
 
 @register_each("ageinfo")
 def ageinfo(item):
+    # Newer archive formats are passing ageinfo as a string here
+    if isinstance(item, (str)):
+        return {item: ''}
+
     return item["ageMeta"]["ageInfo"]
 
 

--- a/twitter_to_sqlite/archive.py
+++ b/twitter_to_sqlite/archive.py
@@ -88,9 +88,9 @@ def ad_online_conversions_unattributed(item):
 
 @register_each("ageinfo")
 def ageinfo(item):
-    # Newer archive formats are passing ageinfo as a string here
-    if isinstance(item, (str)):
-        return {item: ''}
+    # Prevent newer archive formats and/or empty ageinfo files from crashing
+    if isinstance(item, (str)) or "ageInfo" not in item["ageMeta"]:
+        return {'ageInfo': ''}
 
     return item["ageMeta"]["ageInfo"]
 


### PR DESCRIPTION
I'm not sure if this is due to a new format or just because my ageinfo file is blank, but trying to import an archive would crash when it got to that file.  This PR adds a guard clause in the `ageinfo` transformer and sets a default value that doesn't throw an exception.  Seems likely to be the same issue mentioned by danp in https://github.com/dogsheep/twitter-to-sqlite/issues/54, my ageinfo file looks the same.  Added that same ageinfo file to the test archive as well to help confirm my workaround didn't break anything.

Let me know if you want any changes!